### PR TITLE
Compatibility with globalize

### DIFF
--- a/lib/wice/grid_renderer.rb
+++ b/lib/wice/grid_renderer.rb
@@ -367,6 +367,12 @@ module Wice
         end
       end
 
+      # Remove `:translations` from the assoc list. They will be added separately.
+      assocs.delete(:translations) unless assocs.nil?
+      if assocs.is_a?(Array) && assocs.empty?
+        assocs = nil
+      end
+
       klass = Columns::ViewColumn
       if options[:attribute] &&
         col_type_and_table_name = @grid.declare_column(


### PR DESCRIPTION
Makes it possible to use `wice_grid` with `globalize`. Set the `locale` parameter in `initialize_grid`, and then add translated rows as attributes to the `:translations` association. For example

in the controller
`grid = initialize_grid(News, locale: I18n.locale)`

and in the view:
```
<%= grid(@grid) do |g|
  g.column attribute: 'title', assoc: :translations
end -%>
```

Unlike the easy solution `initialize_grid(News.with_translations(:en))`, untranslated attributes
also appear in the grid, and are replaced with fallbacks if they exist.